### PR TITLE
[WIP]: bibtex-tidy

### DIFF
--- a/.github/workflows/bibtex-tidy.yml
+++ b/.github/workflows/bibtex-tidy.yml
@@ -1,0 +1,38 @@
+name: Tidy BibTeX
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'data/bibtex.bib' # Only runs when this specific file changes
+  pull_request:
+    paths:
+      - 'data/bibtex.bib' # Only runs when this specific file changes
+  workflow_dispatch:     # Allows manual triggering
+
+jobs:
+  tidy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'latest'
+
+      - name: Install bibtex-tidy
+        run: npm install -g bibtex-tidy
+
+      - name: Run bibtex-tidy
+        run: |
+          bibtex-tidy data/bibtex.bib \
+            --modify \
+            --omit=abstract,file \
+            --duplicates
+
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore: format data/bibtex.bib"
+          file_pattern: 'data/bibtex.bib'


### PR DESCRIPTION
Adding [bibtex-tidy](https://github.com/FlamingTempura/bibtex-tidy) to CI. Currently: the CI modifies the bibtex and commits the changed file. We could also have it check for compliance and fail if it is not formatted and have a human do the formatting. There are a lot of other options to bibtex-tidy that can be used. At present it removes `abstract` and `file` entries and enforces spacing.